### PR TITLE
Tool build refine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "riga-tool-quote-card",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "riga-tool-quote-card",
-			"version": "0.0.3",
+			"version": "0.0.4",
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^2.0.2",
 				"@sveltejs/kit": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "riga-tool-quote-card",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"scripts": {
 		"predev": "npm run generateConfig",
 		"prebuild": "npm run generateConfig",

--- a/riga-tool.config.yml
+++ b/riga-tool.config.yml
@@ -5,3 +5,10 @@ component: 'Settings'
 package_name: 'riga-tool-quote-card'
 image: 'https://i.ibb.co/JkdZrXj/Blueprint-0.jpg'
 url: 'http://localhost:5174/quote-card'
+settings:
+  quote_text: 'Hello'
+  quote_symbol: '&#10078;'
+  quote_text_size: 3
+  quote_text_color: '#666666'
+  quote_symbol_color: '#f0f0f0'
+  quote_background_color: '#fcfcfc'

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import ColorPicker from './controls/ColorPicker.svelte';
 	import DropDown from './controls/Dropdown.svelte';
+	import config from '../../riga-tool.config.js';
 	// TODO: load types from an external lib both the
 	// editor and the riga settings component can access
 
@@ -19,16 +20,9 @@
 	// export let settings: SettingsWritable;
 	export let settings: any;
 
-	// Define all default settings here. Passed in settings
-	// will overwrite default settings.
-	const defaultSettings = {
-		quote_text: 'Hello',
-		quote_symbol: '&#10078;',
-		quote_text_size: 3,
-		quote_text_color: '#666666',
-		quote_symbol_color: '#f0f0f0',
-		quote_background_color: '#fcfcfc'
-	};
+	// Define default settings in config yaml. Passed in settings
+	// will overwrite these default settings.
+	const defaultSettings = config.settings;
 
 	// Use isLoaded in conjunction with the settings
 	// merge to wait for the render.

--- a/src/routes/quote-card/+page.svelte
+++ b/src/routes/quote-card/+page.svelte
@@ -5,16 +5,16 @@
 	import { onMount } from 'svelte';
 	import './tool-global.css';
 
+	let id = '';
 	let settings = null;
-	let id = null;
 	let loading = true;
 
 	function getId() {
 		// The tool instance id will be passed through as URL param
 		// of the iframe source which we fetch here.
 		const urlParams = new URLSearchParams(window.location.search);
-		const uuid = urlParams.get('instance_id');
-		return uuid ?? null;
+		const toolInstanceId = urlParams.get('tiid');
+		return toolInstanceId || '';
 	}
 
 	async function getSettings(id) {
@@ -54,9 +54,9 @@
 	<!-- The actual tool ui (only showing when data is loaded)-->
 	{#if !loading}
 		{#if !id}
-			<div class="note">Can't find a valid uuid in the the pathname</div>
+			<div class="note">Can't find a valid toolInstanceId in the pathname</div>
 		{:else if !settings}
-			<div class="note">Sorry, can't find any settings for uuid {id}</div>
+			<div class="note">Sorry, can't find any settings for toolInstanceId "{id}""</div>
 		{:else}
 			<div id="tool-ui" style="background-color: {settings.quote_background_color}">
 				<div id="quote-symbol" style="color: {settings.quote_symbol_color}">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	plugins: [sveltekit()],
+	// TODO for dev only - remove for production
+	build: {
+		minify: false
+	},
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}


### PR DESCRIPTION
This PR moves the default settings from the Settings component code to the config yml file so they can be consumed and passed on to the tool instance database immediately to be fetched easily whenever a new tool instance is being created.

It also adds some refactors.